### PR TITLE
Launch action on main thread

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -24,14 +24,18 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(launchCamera:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
-    self.callback = callback;
-    [self launchImagePicker:RNImagePickerTargetCamera options:options];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.callback = callback;
+        [self launchImagePicker:RNImagePickerTargetCamera options:options];
+    });
 }
 
 RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
-    self.callback = callback;
-    [self launchImagePicker:RNImagePickerTargetLibrarySingleImage options:options];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.callback = callback;
+        [self launchImagePicker:RNImagePickerTargetLibrarySingleImage options:options];
+    });
 }
 
 RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)


### PR DESCRIPTION
We need to launch the camera on the main UI thread in order to prevent a silent error